### PR TITLE
cmd: introduce fix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Usage:
 Available Commands:
   add         Add a new/existing file to the profile
   config      Prints information about a profile
+  fix         Tries to fix the configuration file
   help        Help about any command
   init        Initialize a new dotfile profile from the given path.
   install     Install dotfiles from a remote git repository
@@ -164,6 +165,18 @@ hooks.toml. Note: This file won't be symlinked.
 pre_update = [
     "nvim +PlugInstall +qall"
 ]
+```
+
+## Breaking Changes
+
+Although dotm is considered somewhat stable, some breaking changes are expected
+until a 1.0 release. When a breaking change is introduced try to run the fix
+command. This tries to restore the original behaviour by modifying the
+configuration file.
+
+```shell
+# Restore old behaviour by modifying the configuration file
+$ dotm fix
 ```
 
 ## Development

--- a/cmd/dotm/commands/fix.go
+++ b/cmd/dotm/commands/fix.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/relnod/dotm"
+)
+
+const fixHelp = `Tries to fix the configuration file. This command can be used
+after upgrading dotm to fix potential breaking changes in the configuration
+file.
+
+This should the reduce the friction when upgrading dotm.
+
+List of things that get fixed:
+ - set hooks_enabled to true, when not set`
+
+var fixCmd = &cobra.Command{
+	Use:   "fix",
+	Short: "Tries to fix the configuration file",
+	Long:  fixHelp,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return dotm.Fix()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(fixCmd)
+}

--- a/cmd/dotm/testdata/fix.txt
+++ b/cmd/dotm/testdata/fix.txt
@@ -1,0 +1,22 @@
+# Tests the fix command restores the original behaviour
+
+dotm fix
+cmp $HOME/.config/dotm/config.toml $HOME/.config/dotm/config.toml.golden
+
+
+-- home/testuser/.config/dotm/config.toml --
+ignore_prefix = ""
+
+[profiles]
+  [profiles.myprofile]
+    path = ""
+    remote = ""
+
+-- home/testuser/.config/dotm/config.toml.golden --
+ignore_prefix = ""
+
+[profiles]
+  [profiles.myprofile]
+    path = ""
+    remote = ""
+    hooks_enabled = true


### PR DESCRIPTION
This command tries to fix breaking changes in the configuration file.
With the initial implementation the following breaking change gets
fixed:
- set hooks_enabled to true, when not set (Introduced by #37)

Fixes #38