### PR TITLE
cmd/fix: add fixes for breaking changes in 0.3.0

### DIFF
--- a/cmd/dotm/commands/fix.go
+++ b/cmd/dotm/commands/fix.go
@@ -13,7 +13,9 @@ file.
 This should the reduce the friction when upgrading dotm.
 
 List of things that get fixed:
- - set hooks_enabled to true, when not set`
+  - [0.3.0] move config from olf location at $HOME/.dotfiles/dotm.toml
+  - [0.3.0] set ignore_prefix to "_", when not set
+  - [0.4.0] set hooks_enabled to true, when not set`
 
 var fixCmd = &cobra.Command{
 	Use:   "fix",

--- a/cmd/dotm/testdata/fix_config_location.txt
+++ b/cmd/dotm/testdata/fix_config_location.txt
@@ -1,16 +1,19 @@
-# Tests the fix command restores the original behaviour
+# Tests the fix command moves the config file from the old to the new location.
 
 dotm fix
 cmp $HOME/.config/dotm/config.toml $HOME/.config/dotm/config.toml.golden
+# Make sure the old configuration file was deleted
+! exists $HOME/.dotfiles/dotm.toml
 
 
--- home/testuser/.config/dotm/config.toml --
+-- home/testuser/.dotfiles/dotm.toml --
 ignore_prefix = ""
 
 [profiles]
   [profiles.myprofile]
     path = ""
     remote = ""
+    hooks_enabled = true
 
 -- home/testuser/.config/dotm/config.toml.golden --
 ignore_prefix = ""

--- a/cmd/dotm/testdata/fix_missing_hooks_enabled.txt
+++ b/cmd/dotm/testdata/fix_missing_hooks_enabled.txt
@@ -1,0 +1,22 @@
+# Tests the fix command adds hooks_enabled = true when not set
+
+dotm fix
+cmp $HOME/.config/dotm/config.toml $HOME/.config/dotm/config.toml.golden
+
+
+-- home/testuser/.config/dotm/config.toml --
+ignore_prefix = ""
+
+[profiles]
+  [profiles.myprofile]
+    path = ""
+    remote = ""
+
+-- home/testuser/.config/dotm/config.toml.golden --
+ignore_prefix = ""
+
+[profiles]
+  [profiles.myprofile]
+    path = ""
+    remote = ""
+    hooks_enabled = true

--- a/cmd/dotm/testdata/fix_missing_ignore_prefix.txt
+++ b/cmd/dotm/testdata/fix_missing_ignore_prefix.txt
@@ -1,0 +1,20 @@
+# Tests the fix command adds the ignore_prefix="_" when not set
+
+dotm fix
+cmp $HOME/.config/dotm/config.toml $HOME/.config/dotm/config.toml.golden
+
+
+-- home/testuser/.config/dotm/config.toml --
+[profiles]
+  [profiles.myprofile]
+    path = ""
+    remote = ""
+
+-- home/testuser/.config/dotm/config.toml.golden --
+ignore_prefix = "_"
+
+[profiles]
+  [profiles.myprofile]
+    path = ""
+    remote = ""
+    hooks_enabled = true

--- a/config.go
+++ b/config.go
@@ -103,17 +103,26 @@ var ErrOpenConfig = errors.New("failed to open config")
 // ErrDecodeConfig indicates that there is a syntax error in the config file.
 var ErrDecodeConfig = errors.New("failed to decode config")
 
+// loadConfigWithMetaData tries to load the config file at the given path. Also
+// returns the toml metadata.
+func loadConfigWithMetaData(path string) (*Config, toml.MetaData, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, toml.MetaData{}, ErrOpenConfig
+	}
+	c := &Config{}
+	meta, err := toml.Decode(string(data), c)
+	if err != nil {
+		return nil, toml.MetaData{}, ErrDecodeConfig
+	}
+	return c, meta, nil
+}
+
 // LoadConfig loads the config file.
 func LoadConfig() (*Config, error) {
-	c := &Config{}
-
-	data, err := ioutil.ReadFile(configPath)
+	c, _, err := loadConfigWithMetaData(configPath)
 	if err != nil {
-		return nil, ErrOpenConfig
-	}
-	_, err = toml.Decode(string(data), c)
-	if err != nil {
-		return nil, ErrDecodeConfig
+		return nil, err
 	}
 
 	for name, p := range c.Profiles {


### PR DESCRIPTION
This adds fixes for the following things:
 - move config from olf location at $HOME/.dotfiles/dotm.toml
 - set ignore_prefix to "_", when not set