### PR TITLE
uninstall: add option to remove profile

### DIFF
--- a/cmd/dotm/commands/uninstall.go
+++ b/cmd/dotm/commands/uninstall.go
@@ -21,13 +21,17 @@ var uninstallCmd = &cobra.Command{
 	ValidArgs: []string{"$(dotm list)"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return dotm.Uninstall(args[0], &dotm.UninstallOptions{
-			Dry: dry,
+			Dry:   dry,
+			Clean: clean,
 		})
 	},
 }
 
+var clean bool
+
 func init() {
 	uninstallCmd.Flags().BoolVar(&dry, "dry", false, "perfomes a dry run")
+	uninstallCmd.Flags().BoolVar(&clean, "clean", false, "delete the local path and remove profile from config")
 
 	rootCmd.AddCommand(uninstallCmd)
 }

--- a/cmd/dotm/testdata/uninstall_clean.txt
+++ b/cmd/dotm/testdata/uninstall_clean.txt
@@ -1,0 +1,22 @@
+# Tests unistall command removes local path and profile from config when --clean
+# flag was provided
+
+dotm uninstall --clean myprofile
+
+cmp $HOME/.config/dotm/config.toml $HOME/.config/dotm/config.toml.golden
+! exists $HOME/.config/dotm/profiles/myprofile
+
+-- home/testuser/.config/dotm/config.toml --
+ignore_prefix = ""
+
+[profiles]
+  [profiles.myprofile]
+    path = "$HOME/.config/dotm/profiles/myprofile/"
+    remote = ""
+
+-- home/testuser/.config/dotm/profiles/myprofile/bash/.bashrc --
+
+-- home/testuser/.config/dotm/config.toml.golden --
+ignore_prefix = ""
+
+[profiles]

--- a/dotm.go
+++ b/dotm.go
@@ -194,7 +194,8 @@ func update(ctx context.Context, p *Profile, opts *UpdateOptions) (err error) {
 
 // UninstallOptions are the options used to uninstall a dotfile profile.
 type UninstallOptions struct {
-	Dry bool
+	Dry   bool // Dry performes a dry run
+	Clean bool // Clean also removes the local dotfile path and the config entry
 }
 
 // Uninstall unlinks a dotfile profile. If any backup files exist, they get
@@ -214,7 +215,15 @@ func Uninstall(profile string, opts *UninstallOptions) error {
 		return err
 	}
 
-	return c.Write()
+	if opts.Clean {
+		if err := os.RemoveAll(p.expandedPath); err != nil {
+			return err
+		}
+		delete(c.Profiles, profile)
+		return c.Write()
+	}
+
+	return nil
 }
 
 var oldConfigPath = os.ExpandEnv("$HOME/.dotfiles/dotm.toml")


### PR DESCRIPTION
When --clean is provided to the uninstall command, the profile gets
removed from the config and the local path gets deleted.

Fixes #35